### PR TITLE
Add pyproject.toml

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python setup.py install
+        python -m pip install .
         pip install flake8 pytest wheel torch
     - name: Test with pytest
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["wheel", "setuptools", "oldest-supported-numpy"]

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,6 @@
 from setuptools import setup, find_packages, Extension
-from setuptools.command.build_ext import build_ext as _build_ext
-
-
-class build_ext(_build_ext):
-    def finalize_options(self):
-        _build_ext.finalize_options(self)
-        # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
-        import numpy
-        self.include_dirs.append(numpy.get_include())
+from setuptools.command.build_ext import build_ext
+import numpy
 
 
 try:
@@ -20,8 +12,12 @@ except ImportError:
 # https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html
 ext = '.pyx' if USE_CYTHON else '.c'
 extensions = [
-    Extension("ctc_segmentation.ctc_segmentation_dyn",
-             ["ctc_segmentation/ctc_segmentation_dyn"+ext])]
+    Extension(
+        name="ctc_segmentation.ctc_segmentation_dyn",
+        include_dirs=[numpy.get_include()],
+        sources=["ctc_segmentation/ctc_segmentation_dyn"+ext]
+    )
+]
 if USE_CYTHON:
     from Cython.Build import cythonize
     extensions = cythonize(extensions)


### PR DESCRIPTION
HI, 

This PR has two purposes:

- The following hack for `numpy.get_include()` is no longer required since we can specify the build environment putting pyproject.toml

https://github.com/lumaku/ctc-segmentation/blob/1170c6ce9e6c6ac23afae33edec14679b785e34f/setup.py#L5-L12

- To avoid the following issues, `oldest-supported-numpy` is used for building instead of `numpy`: https://github.com/scipy/oldest-supported-numpy

```
ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```

Numpy-ABI is compatible with newer numpy, but incompatible with older numpy, thus the best practice is to build modules with the oldest numpy. 

Fortunately, scipy organizers maintain the  `oldest-supported-numpy`. I think this way is reliable.

(Alternative solution is, without specifying numpy version in `setup.py`/`pyproject.toml`, rather, distributing the wheel file with the oldest numpy)