### PR TITLE
Fix poetry install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["wheel", "setuptools", "oldest-supported-numpy", "Cython"]
+requires = ["wheel", "setuptools", "numpy", "Cython"]


### PR DESCRIPTION
Solved the following error that occured with `poetry install`.

## environment
- poetry: 1.7.0
- python: 3.8.7
- ubuntu: 18.04

## pyproject.toml
```
[tool.poetry.dependencies]
python = "^3.8"
ctc-segmentation = "1.7.4"

[build-system]
requires = ["poetry>=0.12"]
build-backend = "poetry.masonry.api"
```

## error
```
Installing dependencies from lock file

Package operations: 0 installs, 1 update, 0 removals

  • Updating ctc-segmentation (1.7.4 cf0c13e -> 1.7.4): Failed

  OverrideNeeded

  ({Package('oldest-supported-numpy', '2023.10.25'): {'numpy': <Dependency numpy (==1.22.2)>}}, {Package('oldest-supported-numpy', '2023.10.25'): {'numpy': <Dependency numpy (==1.19.2)>}}, {Package('oldest-supported-numpy', '2023.10.25'): {'numpy': <Dependency numpy (==1.21.0)>}}, {Package('oldest-supported-numpy', '2023.10.25'): {'numpy': <Dependency numpy (==1.17.3)>}}, {Package('oldest-supported-numpy', '2023.10.25'): {'numpy': <Dependency numpy (==1.17.5)>}}, {Package('oldest-supported-numpy', '2023.10.25'): {'numpy': <Dependency numpy (<empty>)>}})

  at ~/.local/share/pypoetry/venv/lib/python3.8/site-packages/poetry/puzzle/provider.py:660 in complete_package
      656│                     current_overrides.update({dependency_package: package_overrides})
      657│                     overrides.append(current_overrides)
      658│ 
      659│             if overrides:
    → 660│                 raise OverrideNeeded(*overrides)
      661│ 
      662│         # Modifying dependencies as needed
      663│         clean_dependencies = []
      664│         for dep in dependencies:

The following error occurred when trying to handle this error:


  OverrideNeeded

  {Package('oldest-supported-numpy', '2023.10.25'): {'numpy': <Dependency numpy (==1.22.2)>}, Package('oldest-supported-numpy', '2023.8.3'): {'numpy': <Dependency numpy (==1.22.2)>}}

  at ~/.local/share/pypoetry/venv/lib/python3.8/site-packages/poetry/puzzle/provider.py:660 in complete_package
      656│                     current_overrides.update({dependency_package: package_overrides})
      657│                     overrides.append(current_overrides)
      658│ 
      659│             if overrides:
    → 660│                 raise OverrideNeeded(*overrides)
      661│ 
      662│         # Modifying dependencies as needed
      663│         clean_dependencies = []
      664│         for dep in dependencies:

The following error occurred when trying to handle this error:


  IncompatibleConstraintsError

  Incompatible constraints in requirements of oldest-supported-numpy (2022.11.19):
  numpy (==1.22.2) ; platform_machine == "loongarch64" and python_version < "3.11" or python_version == "3.8" and platform_python_implementation == "PyPy"
  numpy (==1.21.0) ; python_version == "3.8" and platform_machine == "arm64" and platform_system == "Darwin"

  at ~/.local/share/pypoetry/venv/lib/python3.8/site-packages/poetry/puzzle/provider.py:920 in _resolve_overlapping_markers
      916│                     specific_source_dependency = dep
      917│                 constraint = constraint.intersect(dep.constraint)
      918│             if constraint.is_empty():
      919│                 # conflict in overlapping area
    → 920│                 raise IncompatibleConstraintsError(package, *used_dependencies)
      921│ 
      922│             if not any(uses):
      923│                 # This is an edge case where the dependency is not required
      924│                 # for the resulting marker. However, we have to consider it anyway

Cannot install ctc-segmentation.
```